### PR TITLE
Adding support for converting the 'className' property

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports.convert = function (code) {
                     if (property.key.name === "template" && property.value.type === "JSXElement") {
                         var templateStr = recast.print(property.value).code;
                         templateStr = templateStr.replace(/(\r\n|\n|\r)/g,'\n');
+                        templateStr = templateStr.replace(/<(.*)className="(.*)"(.*)>/gi, "<$1class=\"$2\"$3>");
                         property.value = b.literal(templateStr);
                     }
                 }


### PR DESCRIPTION
 This pull request adds support for converting the 'className' property in the JSX template to 'class' property in the JS output.

'className' is the proper JSX property name, and tooling like Visual Studio's JSX syntax highlighting doesn't support using 'class' in a JSX template.
